### PR TITLE
Develop command working on Windows again

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,6 @@ trim_trailing_whitespace = true
 quote_type = single
 max_line_length = 120
 
-[*.py]
-
 [*.md]
 trim_trailing_whitespace = false
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 quote_type = single
+max_line_length = 120
 
 [*.py]
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,9 @@ indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+quote_type = single
+
+[*.py]
 
 [*.md]
 trim_trailing_whitespace = false

--- a/resources/js/electron-builder.js
+++ b/resources/js/electron-builder.js
@@ -35,7 +35,7 @@ switch (targetOs) {
         break;
 }
 
-if (isWindows || osTarget == 'win') {
+if (isWindows || targetOs == 'win') {
     targetOs = 'win';
     phpBinaryFilename += '.exe';
 } else if (isLinux) {

--- a/resources/js/electron-builder.js
+++ b/resources/js/electron-builder.js
@@ -1,8 +1,8 @@
-const {copySync, removeSync, writeJsonSync, existsSync} = require("fs-extra");
-const {join} = require("path");
+const { copySync, removeSync, writeJsonSync, existsSync } = require('fs-extra');
+const { join } = require('path');
 const os = require('os');
-const {mkdtempSync} = require("fs");
-const {execSync} = require("child_process");
+const { mkdtempSync } = require('fs');
+const { execSync } = require('child_process');
 const isBuilding = process.env.NATIVEPHP_BUILDING == 1;
 const appId = process.env.NATIVEPHP_APP_ID;
 const appName = process.env.NATIVEPHP_APP_NAME;
@@ -26,14 +26,14 @@ if (isLinux) {
     targetOs = 'linux';
 }
 
-let binaryArch = 'x86';
+let binaryArch = process.arch;
 if (isArm64) {
     binaryArch = 'arm64';
-}
-if (isWindows || isLinux) {
+} else if (isWindows || isLinux) {
     binaryArch = 'x64';
+} else if (isDarwin) {
+    binaryArch = 'x86';
 }
-
 
 let updaterConfig = {};
 
@@ -43,8 +43,8 @@ console.log('Binary Filename: ', phpBinaryFilename);
 const binarySrcDir = join(phpBinaryPath, targetOs, binaryArch);
 const binaryDestDir = join(__dirname, 'resources/php');
 
-console.log("Arch: ", process.arch)
-console.log("Platform: ", process.platform)
+console.log('Arch: ', process.arch);
+console.log('Platform: ', process.platform);
 try {
     updaterConfig = process.env.NATIVEPHP_UPDATER_CONFIG;
     updaterConfig = JSON.parse(updaterConfig);
@@ -59,7 +59,8 @@ if (phpBinaryPath) {
         copySync(binarySrcDir, binaryDestDir);
         // If we're on Windows, copy the php.exe from the dest dir to `php`.
         // This allows the same import command to work on all platforms (same binary filename)
-        if (isWindows && existsSync(join(binaryDestDir, phpBinaryFilename))) {
+        if (targetOs == 'win' && existsSync(join(binaryDestDir, phpBinaryFilename))) {
+            console.log('Copying PHP executable from php.exe to just php for cross env compatibility');
             copySync(join(binaryDestDir, phpBinaryFilename), join(binaryDestDir, 'php'));
         }
         console.log('Copied PHP binary to ', binaryDestDir);
@@ -118,19 +119,19 @@ if (isBuilding) {
                 });
 
                 return !shouldSkip;
-            }
+            },
         });
 
         copySync(tmpDir, join(__dirname, 'resources', 'app'));
 
         // Electron build removes empty folders, so we have to create dummy files
         // dotfiles unfortunately don't work.
-        writeJsonSync(join(__dirname, 'resources', 'app', 'storage', 'framework', 'cache', '_native.json'), {})
-        writeJsonSync(join(__dirname, 'resources', 'app', 'storage', 'framework', 'sessions', '_native.json'), {})
-        writeJsonSync(join(__dirname, 'resources', 'app', 'storage', 'framework', 'testing', '_native.json'), {})
-        writeJsonSync(join(__dirname, 'resources', 'app', 'storage', 'framework', 'views', '_native.json'), {})
-        writeJsonSync(join(__dirname, 'resources', 'app', 'storage', 'app', 'public', '_native.json'), {})
-        writeJsonSync(join(__dirname, 'resources', 'app', 'storage', 'logs', '_native.json'), {})
+        writeJsonSync(join(__dirname, 'resources', 'app', 'storage', 'framework', 'cache', '_native.json'), {});
+        writeJsonSync(join(__dirname, 'resources', 'app', 'storage', 'framework', 'sessions', '_native.json'), {});
+        writeJsonSync(join(__dirname, 'resources', 'app', 'storage', 'framework', 'testing', '_native.json'), {});
+        writeJsonSync(join(__dirname, 'resources', 'app', 'storage', 'framework', 'views', '_native.json'), {});
+        writeJsonSync(join(__dirname, 'resources', 'app', 'storage', 'app', 'public', '_native.json'), {});
+        writeJsonSync(join(__dirname, 'resources', 'app', 'storage', 'logs', '_native.json'), {});
 
         removeSync(tmpDir);
 
@@ -140,14 +141,15 @@ if (isBuilding) {
         console.log('=====================');
 
         // We'll use the default PHP binary here, as we can cross-compile for all platforms
-        execSync(`php ${join(__dirname, 'resources', 'app', 'artisan')} native:minify ${join(__dirname, 'resources', 'app')}`);
+        execSync(
+            `php ${join(__dirname, 'resources', 'app', 'artisan')} native:minify ${join(__dirname, 'resources', 'app')}`
+        );
     } catch (e) {
         console.error('=====================');
         console.error('Error copying app to resources');
         console.error(e);
         console.error('=====================');
     }
-
 }
 
 const deepLinkProtocol = 'nativephp';
@@ -166,9 +168,7 @@ module.exports = {
         '!{.eslintignore,.eslintrc.cjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,CHANGELOG.md,README.md}',
         '!{.env,.env.*,.npmrc,pnpm-lock.yaml}',
     ],
-    asarUnpack: [
-        'resources/**',
-    ],
+    asarUnpack: ['resources/**'],
     afterSign: 'build/notarize.js',
     win: {
         executableName: fileName,
@@ -191,14 +191,10 @@ module.exports = {
         },
         artifactName: appName + '-${version}-${arch}.${ext}',
         extendInfo: {
-            NSCameraUsageDescription:
-                "Application requests access to the device's camera.",
-            NSMicrophoneUsageDescription:
-                "Application requests access to the device's microphone.",
-            NSDocumentsFolderUsageDescription:
-                "Application requests access to the user's Documents folder.",
-            NSDownloadsFolderUsageDescription:
-                "Application requests access to the user's Downloads folder.",
+            NSCameraUsageDescription: "Application requests access to the device's camera.",
+            NSMicrophoneUsageDescription: "Application requests access to the device's microphone.",
+            NSDocumentsFolderUsageDescription: "Application requests access to the user's Documents folder.",
+            NSDownloadsFolderUsageDescription: "Application requests access to the user's Downloads folder.",
         },
     },
     dmg: {
@@ -219,5 +215,5 @@ module.exports = {
         homepage: appUrl,
         version: appVersion,
         author: appAuthor,
-    }
+    },
 };

--- a/resources/js/electron-builder.js
+++ b/resources/js/electron-builder.js
@@ -16,16 +16,20 @@ const isArm64 = process.argv.includes('--arm64');
 const isWindows = process.argv.includes('--win');
 const isLinux = process.argv.includes('--linux');
 const isDarwin = process.argv.includes('--mac');
-let targetOs = 'mac';
 let phpBinaryFilename = 'php';
+// Default to the current platform for develop mode. Build will pass in an arg that overrides this
+let targetOs = process.platform;
+
 if (isWindows) {
     targetOs = 'win';
     phpBinaryFilename += '.exe';
-}
-if (isLinux) {
+} else if (isLinux) {
     targetOs = 'linux';
+} else if (isDarwin) {
+	targetOs = 'mac';
 }
 
+// Default to the current arch for develop mode. Build will pass in an arg that overrides this
 let binaryArch = process.arch;
 if (isArm64) {
     binaryArch = 'arm64';

--- a/resources/js/electron-builder.js
+++ b/resources/js/electron-builder.js
@@ -20,13 +20,28 @@ let phpBinaryFilename = 'php';
 // Default to the current platform for develop mode. Build will pass in an arg that overrides this
 let targetOs = process.platform;
 
-if (isWindows) {
+switch (targetOs) {
+    case 'win32':
+        targetOs = 'win';
+        break;
+    case 'darwin':
+        targetOs = 'mac';
+        break;
+    case 'linux':
+        targetOs = 'linux';
+        break;
+    default:
+        throw new Error('Unsupported platform: ' + targetOs);
+        break;
+}
+
+if (isWindows || osTarget == 'win') {
     targetOs = 'win';
     phpBinaryFilename += '.exe';
 } else if (isLinux) {
     targetOs = 'linux';
 } else if (isDarwin) {
-	targetOs = 'mac';
+    targetOs = 'mac';
 }
 
 // Default to the current arch for develop mode. Build will pass in an arg that overrides this

--- a/resources/js/package-lock.json
+++ b/resources/js/package-lock.json
@@ -12,7 +12,7 @@
         "@electron-toolkit/preload": "^1.0.3",
         "@electron-toolkit/utils": "^1.0.2",
         "@electron/remote": "^2.0.9",
-        "@nativephp/electron-plugin": "^0.1.0"
+        "@nativephp/electron-plugin": "^0.1"
       },
       "devDependencies": {
         "@electron/notarize": "^1.2.3",

--- a/resources/js/package-lock.json
+++ b/resources/js/package-lock.json
@@ -677,9 +677,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.16.tgz",
-      "integrity": "sha512-gCHjjQmA8L0soklKbLKA6pgsLk1byULuHe94lkZDzcO3/Ta+bbeewJioEn1Fr7kgy9NWNFy/C+MrBwC6I/WCug==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.17.tgz",
+      "integrity": "sha512-wHsmJG/dnL3OkpAcwbgoBTTMHVi4Uyou3F5mf58ZtmUyIKfcdA7TROav/6tCzET4A3QW2Q2FC+eFneMU+iyOxg==",
       "cpu": [
         "arm"
       ],
@@ -693,9 +693,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.16.tgz",
-      "integrity": "sha512-wsCqSPqLz+6Ov+OM4EthU43DyYVVyfn15S4j1bJzylDpc1r1jZFFfJQNfDuT8SlgwuqpmpJXK4uPlHGw6ve7eA==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.17.tgz",
+      "integrity": "sha512-9np+YYdNDed5+Jgr1TdWBsozZ85U1Oa3xW0c7TWqH0y2aGghXtZsuT8nYRbzOMcl0bXZXjOGbksoTtVOlWrRZg==",
       "cpu": [
         "arm64"
       ],
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.16.tgz",
-      "integrity": "sha512-ldsTXolyA3eTQ1//4DS+E15xl0H/3DTRJaRL0/0PgkqDsI0fV/FlOtD+h0u/AUJr+eOTlZv4aC9gvfppo3C4sw==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.17.tgz",
+      "integrity": "sha512-O+FeWB/+xya0aLg23hHEM2E3hbfwZzjqumKMSIqcHbNvDa+dza2D0yLuymRBQQnC34CWrsJUXyH2MG5VnLd6uw==",
       "cpu": [
         "x64"
       ],
@@ -725,9 +725,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.16.tgz",
-      "integrity": "sha512-aBxruWCII+OtluORR/KvisEw0ALuw/qDQWvkoosA+c/ngC/Kwk0lLaZ+B++LLS481/VdydB2u6tYpWxUfnLAIw==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.17.tgz",
+      "integrity": "sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==",
       "cpu": [
         "arm64"
       ],
@@ -741,9 +741,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.16.tgz",
-      "integrity": "sha512-6w4Dbue280+rp3LnkgmriS1icOUZDyPuZo/9VsuMUTns7SYEiOaJ7Ca1cbhu9KVObAWfmdjUl4gwy9TIgiO5eA==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.17.tgz",
+      "integrity": "sha512-XDre+J5YeIJDMfp3n0279DFNrGCXlxOuGsWIkRb1NThMZ0BsrWXoTg23Jer7fEXQ9Ye5QjrvXpxnhzl3bHtk0g==",
       "cpu": [
         "x64"
       ],
@@ -757,9 +757,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.16.tgz",
-      "integrity": "sha512-x35fCebhe9s979DGKbVAwXUOcTmCIE32AIqB9CB1GralMIvxdnMLAw5CnID17ipEw9/3MvDsusj/cspYt2ZLNQ==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.17.tgz",
+      "integrity": "sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==",
       "cpu": [
         "arm64"
       ],
@@ -773,9 +773,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.16.tgz",
-      "integrity": "sha512-YM98f+PeNXF3GbxIJlUsj+McUWG1irguBHkszCIwfr3BXtXZsXo0vqybjUDFfu9a8Wr7uUD/YSmHib+EeGAFlg==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.17.tgz",
+      "integrity": "sha512-sOxEvR8d7V7Kw8QqzxWc7bFfnWnGdaFBut1dRUYtu+EIRXefBc/eIsiUiShnW0hM3FmQ5Zf27suDuHsKgZ5QrA==",
       "cpu": [
         "x64"
       ],
@@ -789,9 +789,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.16.tgz",
-      "integrity": "sha512-b5ABb+5Ha2C9JkeZXV+b+OruR1tJ33ePmv9ZwMeETSEKlmu/WJ45XTTG+l6a2KDsQtJJ66qo/hbSGBtk0XVLHw==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.17.tgz",
+      "integrity": "sha512-2d3Lw6wkwgSLC2fIvXKoMNGVaeY8qdN0IC3rfuVxJp89CRfA3e3VqWifGDfuakPmp90+ZirmTfye1n4ncjv2lg==",
       "cpu": [
         "arm"
       ],
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.16.tgz",
-      "integrity": "sha512-XIqhNUxJiuy+zsR77+H5Z2f7s4YRlriSJKtvx99nJuG5ATuJPjmZ9n0ANgnGlPCpXGSReFpgcJ7O3SMtzIFeiQ==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.17.tgz",
+      "integrity": "sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==",
       "cpu": [
         "arm64"
       ],
@@ -821,9 +821,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.16.tgz",
-      "integrity": "sha512-no+pfEpwnRvIyH+txbBAWtjxPU9grslmTBfsmDndj7bnBmr55rOo/PfQmRfz7Qg9isswt1FP5hBbWb23fRWnow==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.17.tgz",
+      "integrity": "sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==",
       "cpu": [
         "ia32"
       ],
@@ -837,9 +837,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.16.tgz",
-      "integrity": "sha512-Zbnczs9ZXjmo0oZSS0zbNlJbcwKXa/fcNhYQjahDs4Xg18UumpXG/lwM2lcSvHS3mTrRyCYZvJbmzYc4laRI1g==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.17.tgz",
+      "integrity": "sha512-EvLsxCk6ZF0fpCB6w6eOI2Fc8KW5N6sHlIovNe8uOFObL2O+Mr0bflPHyHwLT6rwMg9r77WOAWb2FqCQrVnwFg==",
       "cpu": [
         "loong64"
       ],
@@ -853,9 +853,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.16.tgz",
-      "integrity": "sha512-YMF7hih1HVR/hQVa/ot4UVffc5ZlrzEb3k2ip0nZr1w6fnYypll9td2qcoMLvd3o8j3y6EbJM3MyIcXIVzXvQQ==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.17.tgz",
+      "integrity": "sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==",
       "cpu": [
         "mips64el"
       ],
@@ -869,9 +869,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.16.tgz",
-      "integrity": "sha512-Wkz++LZ29lDwUyTSEnzDaaP5OveOgTU69q9IyIw9WqLRxM4BjTBjz9un4G6TOvehWpf/J3gYVFN96TjGHrbcNQ==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.17.tgz",
+      "integrity": "sha512-BAAilJ0M5O2uMxHYGjFKn4nJKF6fNCdP1E0o5t5fvMYYzeIqy2JdAP88Az5LHt9qBoUa4tDaRpfWt21ep5/WqQ==",
       "cpu": [
         "ppc64"
       ],
@@ -885,9 +885,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.16.tgz",
-      "integrity": "sha512-LFMKZ30tk78/mUv1ygvIP+568bwf4oN6reG/uczXnz6SvFn4e2QUFpUpZY9iSJT6Qpgstrhef/nMykIXZtZWGQ==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.17.tgz",
+      "integrity": "sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==",
       "cpu": [
         "riscv64"
       ],
@@ -901,9 +901,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.16.tgz",
-      "integrity": "sha512-3ZC0BgyYHYKfZo3AV2/66TD/I9tlSBaW7eWTEIkrQQKfJIifKMMttXl9FrAg+UT0SGYsCRLI35Gwdmm96vlOjg==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.17.tgz",
+      "integrity": "sha512-j/34jAl3ul3PNcK3pfI0NSlBANduT2UO5kZ7FCaK33XFv3chDhICLY8wJJWIhiQ+YNdQ9dxqQctRg2bvrMlYgg==",
       "cpu": [
         "s390x"
       ],
@@ -917,9 +917,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.16.tgz",
-      "integrity": "sha512-xu86B3647DihHJHv/wx3NCz2Dg1gjQ8bbf9cVYZzWKY+gsvxYmn/lnVlqDRazObc3UMwoHpUhNYaZset4X8IPA==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.17.tgz",
+      "integrity": "sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==",
       "cpu": [
         "x64"
       ],
@@ -933,9 +933,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.16.tgz",
-      "integrity": "sha512-uVAgpimx9Ffw3xowtg/7qQPwHFx94yCje+DoBx+LNm2ePDpQXHrzE+Sb0Si2VBObYz+LcRps15cq+95YM7gkUw==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.17.tgz",
+      "integrity": "sha512-/jGlhWR7Sj9JPZHzXyyMZ1RFMkNPjC6QIAan0sDOtIo2TYk3tZn5UDrkE0XgsTQCxWTTOcMPf9p6Rh2hXtl5TQ==",
       "cpu": [
         "x64"
       ],
@@ -949,9 +949,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.16.tgz",
-      "integrity": "sha512-6OjCQM9wf7z8/MBi6BOWaTL2AS/SZudsZtBziXMtNI8r/U41AxS9x7jn0ATOwVy08OotwkPqGRMkpPR2wcTJXA==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.17.tgz",
+      "integrity": "sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==",
       "cpu": [
         "x64"
       ],
@@ -965,9 +965,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.16.tgz",
-      "integrity": "sha512-ZoNkruFYJp9d1LbUYCh8awgQDvB9uOMZqlQ+gGEZR7v6C+N6u7vPr86c+Chih8niBR81Q/bHOSKGBK3brJyvkQ==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.17.tgz",
+      "integrity": "sha512-Y7ZBbkLqlSgn4+zot4KUNYst0bFoO68tRgI6mY2FIM+b7ZbyNVtNbDP5y8qlu4/knZZ73fgJDlXID+ohY5zt5g==",
       "cpu": [
         "x64"
       ],
@@ -981,9 +981,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.16.tgz",
-      "integrity": "sha512-+j4anzQ9hrs+iqO+/wa8UE6TVkKua1pXUb0XWFOx0FiAj6R9INJ+WE//1/Xo6FG1vB5EpH3ko+XcgwiDXTxcdw==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.17.tgz",
+      "integrity": "sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==",
       "cpu": [
         "arm64"
       ],
@@ -997,9 +997,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.16.tgz",
-      "integrity": "sha512-5PFPmq3sSKTp9cT9dzvI67WNfRZGvEVctcZa1KGjDDu4n3H8k59Inbk0du1fz0KrAbKKNpJbdFXQMDUz7BG4rQ==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.17.tgz",
+      "integrity": "sha512-H/XaPtPKli2MhW+3CQueo6Ni3Avggi6hP/YvgkEe1aSaxw+AeO8MFjq8DlgfTd9Iz4Yih3QCZI6YLMoyccnPRg==",
       "cpu": [
         "ia32"
       ],
@@ -1013,9 +1013,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.16.tgz",
-      "integrity": "sha512-sCIVrrtcWN5Ua7jYXNG1xD199IalrbfV2+0k/2Zf2OyV2FtnQnMgdzgpRAbi4AWlKJj1jkX+M+fEGPQj6BQB4w==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.17.tgz",
+      "integrity": "sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==",
       "cpu": [
         "x64"
       ],
@@ -1044,9 +1044,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.0.tgz",
-      "integrity": "sha512-uiPeRISaglZnaZk8vwrjQZ1CxogZeY/4IYft6gBOTqu1WhVXWmCmZMWxUv2Q/pxSvPdp1JPaO62kLOcOkMqWrw==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1280,9 +1280,9 @@
       }
     },
     "node_modules/@nativephp/electron-plugin": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/chrisreedio/electron-plugin.git#08c9c4b1cc2cb292a5f2ac90993120e8861cc9a3",
-      "license": "MIT",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@nativephp/electron-plugin/-/electron-plugin-0.1.2.tgz",
+      "integrity": "sha512-MqVsFfGcsfWN13n/gSveXf/jSE1RYlq4mzBwAjkd7vPBnLRTrQ/uLT/Ztbb/c6+OXlRjN52XlUNWDb4+xTeg9A==",
       "dependencies": {
         "@electron-toolkit/utils": "^1.0.2",
         "@electron/remote": "^2.0.9",
@@ -1480,9 +1480,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.17.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.0.tgz",
-      "integrity": "sha512-GXZxEtOxYGFchyUzxvKI14iff9KZ2DI+A6a37o6EQevtg6uO9t+aUZKcaC1Te5Ng1OnLM7K9NVVj+FbecD9cJg=="
+      "version": "18.17.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.1.tgz",
+      "integrity": "sha512-xlR1jahfizdplZYRU59JlUx9uzF1ARa8jbhM11ccpCJya8kvos5jwdm2ZAgxSCwOl0fq21svP18EVwPBXMQudw=="
     },
     "node_modules/@types/plist": {
       "version": "3.0.2",
@@ -1813,9 +1813,9 @@
       "dev": true
     },
     "node_modules/app-builder-lib": {
-      "version": "24.6.2",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.6.2.tgz",
-      "integrity": "sha512-+tkGvSuSsXPZlkKLgZUF+yVTqccAGsXFo6Scte9sn3AWMD6YqrYwnEJPkapzmf0a+H6lqMoiGKrQxTWiskMfbw==",
+      "version": "24.6.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.6.3.tgz",
+      "integrity": "sha512-++0Zp7vcCHfXMBGVj7luFxpqvMPk5mcWeTuw7OK0xNAaNtYQTTN0d9YfWRsb1MvviTOOhyHeULWz1CaixrdrDg==",
       "dev": true,
       "dependencies": {
         "@develar/schema-utils": "~2.6.5",
@@ -2801,12 +2801,12 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "24.6.2",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.6.2.tgz",
-      "integrity": "sha512-/x/iGhvoLUQNaCXi0sNb2K2FJmjylixv4U5gOENievi1zqFs1dGoYkAfpSXDwkUYsZ0J1iNU0LXSlULtTZ6xkg==",
+      "version": "24.6.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.6.3.tgz",
+      "integrity": "sha512-O7KNT7OKqtV54fMYUpdlyTOCP5DoPuRMLqMTgxxV2PO8Hj/so6zOl5o8GTs8pdDkeAhJzCFOUNB3BDhgXbUbJg==",
       "dev": true,
       "dependencies": {
-        "app-builder-lib": "24.6.2",
+        "app-builder-lib": "24.6.3",
         "builder-util": "24.5.0",
         "builder-util-runtime": "9.2.1",
         "fs-extra": "^10.1.0",
@@ -2943,9 +2943,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "25.3.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.3.1.tgz",
-      "integrity": "sha512-t0QXXqgf0/P0OJ9LU3qpcBMK+wL0FRwTQfooBaaG08v5hywPzc1yplfb3l4tS1xC0Ttw8IBaKLBeEoRgxBRHjg==",
+      "version": "25.3.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.3.2.tgz",
+      "integrity": "sha512-xiktJvXraaE/ARf2OVHFyTze1TksSbsbJgOaBtdIiBvUduez6ipATEPIec8Msz1n6eQ+xqYb6YF8tDuIZtJSPw==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
@@ -2960,16 +2960,16 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "24.6.2",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-24.6.2.tgz",
-      "integrity": "sha512-UPJ6L7E4JKRfvJAvB9VI9lCOJHyXqzm6zRUycj9KfrbjTdpDt1c5vce9itvLrNk1UQwgBiPdKYumLfJqNZkO3A==",
+      "version": "24.6.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-24.6.3.tgz",
+      "integrity": "sha512-O6PqhRXwfxCNTXI4BlhELSeYYO6/tqlxRuy+4+xKBokQvwDDjDgZMMoSgAmanVSCuzjE7MZldI9XYrKFk+EQDw==",
       "dev": true,
       "dependencies": {
-        "app-builder-lib": "24.6.2",
+        "app-builder-lib": "24.6.3",
         "builder-util": "24.5.0",
         "builder-util-runtime": "9.2.1",
         "chalk": "^4.1.2",
-        "dmg-builder": "24.6.2",
+        "dmg-builder": "24.6.3",
         "fs-extra": "^10.1.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -3121,9 +3121,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.468",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.468.tgz",
-      "integrity": "sha512-6M1qyhaJOt7rQtNti1lBA0GwclPH+oKCmsra/hkcWs5INLxfXXD/dtdnaKUYQu/pjOBP/8Osoe4mAcNvvzoFag==",
+      "version": "1.4.475",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.475.tgz",
+      "integrity": "sha512-mTye5u5P98kSJO2n7zYALhpJDmoSQejIGya0iR01GpoRady8eK3bw7YHHnjA1Rfi4ZSLdpuzlAC7Zw+1Zu7Z6A==",
       "dev": true
     },
     "node_modules/electron-updater": {
@@ -3298,9 +3298,9 @@
       "optional": true
     },
     "node_modules/esbuild": {
-      "version": "0.18.16",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.16.tgz",
-      "integrity": "sha512-1xLsOXrDqwdHxyXb/x/SOyg59jpf/SH7YMvU5RNSU7z3TInaASNJWNFJ6iRvLvLETZMasF3d1DdZLg7sgRimRQ==",
+      "version": "0.18.17",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.17.tgz",
+      "integrity": "sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -3310,28 +3310,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.16",
-        "@esbuild/android-arm64": "0.18.16",
-        "@esbuild/android-x64": "0.18.16",
-        "@esbuild/darwin-arm64": "0.18.16",
-        "@esbuild/darwin-x64": "0.18.16",
-        "@esbuild/freebsd-arm64": "0.18.16",
-        "@esbuild/freebsd-x64": "0.18.16",
-        "@esbuild/linux-arm": "0.18.16",
-        "@esbuild/linux-arm64": "0.18.16",
-        "@esbuild/linux-ia32": "0.18.16",
-        "@esbuild/linux-loong64": "0.18.16",
-        "@esbuild/linux-mips64el": "0.18.16",
-        "@esbuild/linux-ppc64": "0.18.16",
-        "@esbuild/linux-riscv64": "0.18.16",
-        "@esbuild/linux-s390x": "0.18.16",
-        "@esbuild/linux-x64": "0.18.16",
-        "@esbuild/netbsd-x64": "0.18.16",
-        "@esbuild/openbsd-x64": "0.18.16",
-        "@esbuild/sunos-x64": "0.18.16",
-        "@esbuild/win32-arm64": "0.18.16",
-        "@esbuild/win32-ia32": "0.18.16",
-        "@esbuild/win32-x64": "0.18.16"
+        "@esbuild/android-arm": "0.18.17",
+        "@esbuild/android-arm64": "0.18.17",
+        "@esbuild/android-x64": "0.18.17",
+        "@esbuild/darwin-arm64": "0.18.17",
+        "@esbuild/darwin-x64": "0.18.17",
+        "@esbuild/freebsd-arm64": "0.18.17",
+        "@esbuild/freebsd-x64": "0.18.17",
+        "@esbuild/linux-arm": "0.18.17",
+        "@esbuild/linux-arm64": "0.18.17",
+        "@esbuild/linux-ia32": "0.18.17",
+        "@esbuild/linux-loong64": "0.18.17",
+        "@esbuild/linux-mips64el": "0.18.17",
+        "@esbuild/linux-ppc64": "0.18.17",
+        "@esbuild/linux-riscv64": "0.18.17",
+        "@esbuild/linux-s390x": "0.18.17",
+        "@esbuild/linux-x64": "0.18.17",
+        "@esbuild/netbsd-x64": "0.18.17",
+        "@esbuild/openbsd-x64": "0.18.17",
+        "@esbuild/sunos-x64": "0.18.17",
+        "@esbuild/win32-arm64": "0.18.17",
+        "@esbuild/win32-ia32": "0.18.17",
+        "@esbuild/win32-x64": "0.18.17"
       }
     },
     "node_modules/escalade": {
@@ -3423,9 +3423,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.9.0.tgz",
+      "integrity": "sha512-+sbni7NfVXnOpnRadUA8S28AUlsZt9GjgFvABIRL9Hkn8KqNzOp+7Lw4QWtrwn20KzU3wqu1QoOj2m+7rKRqkA==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -6421,9 +6421,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
       "devOptional": true
     },
     "node_modules/type-check": {
@@ -6598,9 +6598,9 @@
       "optional": true
     },
     "node_modules/vite": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.6.tgz",
-      "integrity": "sha512-EY6Mm8vJ++S3D4tNAckaZfw3JwG3wa794Vt70M6cNJ6NxT87yhq7EC8Rcap3ahyHdo8AhCmV9PTk+vG1HiYn1A==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.7.tgz",
+      "integrity": "sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/resources/js/yarn.lock
+++ b/resources/js/yarn.lock
@@ -398,7 +398,7 @@
     lodash "^4.17.15"
     tmp-promise "^3.0.2"
 
-"@nativephp/electron-plugin@^0.1.0":
+"@nativephp/electron-plugin@^0.1":
   version "0.1.0"
   resolved "git+ssh://git@github.com/chrisreedio/electron-plugin.git#08c9c4b1cc2cb292a5f2ac90993120e8861cc9a3"
   dependencies:


### PR DESCRIPTION
The prior work had broken the develop command on Windows.
The develop command should take the current OS / arch into account since it will be running locally on that system.
The build scripts pass in flags to override the target platform/arch.